### PR TITLE
Add new attr_arraySort and Toy_createArray

### DIFF
--- a/source/toy_array.c
+++ b/source/toy_array.c
@@ -4,6 +4,22 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+Toy_Array* Toy_createArray(unsigned int capacity) {
+    size_t size = sizeof(Toy_Array) + ((size_t)capacity * sizeof(Toy_Value));
+    Toy_Array* arr = malloc(size);
+    if (arr == NULL) {
+        fprintf(stderr,
+            "ERROR: Failed to allocate Toy_Array with capacity %u\n",
+            capacity
+        );
+		exit(-1);
+	}
+
+    arr->capacity = capacity;
+    arr->count = 0;
+    return arr;
+}
+
 Toy_Array* Toy_resizeArray(Toy_Array* paramArray, unsigned int capacity) {
 	//if some values will be removed, free them first
 	if (paramArray != NULL && paramArray->count > capacity) {
@@ -20,7 +36,8 @@ Toy_Array* Toy_resizeArray(Toy_Array* paramArray, unsigned int capacity) {
 
 	unsigned int originalCapacity = paramArray == NULL ? 0 : paramArray->capacity;
 
-	Toy_Array* array = realloc(paramArray, capacity * sizeof(Toy_Value) + sizeof(Toy_Array));
+	size_t size = sizeof(Toy_Array) + ((size_t)capacity * sizeof(Toy_Value));
+	Toy_Array* array = realloc(paramArray, size);
 
 	if (array == NULL) {
 		fprintf(stderr, TOY_CC_ERROR "ERROR: Failed to resize a 'Toy_Array' from %d to %d capacity\n" TOY_CC_RESET, (int)originalCapacity, (int)capacity);

--- a/source/toy_array.h
+++ b/source/toy_array.h
@@ -12,6 +12,8 @@ typedef struct Toy_Array { //32 | 64 BITNESS
 
 TOY_API Toy_Array* Toy_resizeArray(Toy_Array* array, unsigned int capacity);
 
+TOY_API Toy_Array* Toy_createArray(unsigned int capacity);
+
 //some useful sizes, could be swapped out as needed
 #ifndef TOY_ARRAY_INITIAL_CAPACITY
 #define TOY_ARRAY_INITIAL_CAPACITY 8

--- a/source/toy_attributes.c
+++ b/source/toy_attributes.c
@@ -1,5 +1,7 @@
 #include "toy_attributes.h"
-#include "toy_console_colors.h"
+#include "toy_array.h"
+#include "toy_sort.h"
+#include "toy_value.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -13,6 +15,20 @@ static Toy_OpaqueAttributeHandler opaqueAttributeCallback = NULL;
 #define MATCH_VALUE_AND_CSTRING(value, cstring) \
 	((TOY_VALUE_AS_STRING(value)->info.length == strlen(cstring)) && \
 	(strncmp(cstring, TOY_VALUE_AS_STRING(value)->leaf.data, TOY_VALUE_AS_STRING(value)->info.length) == 0))
+
+static void attr_arraySort(Toy_VM* vm, Toy_FunctionNative* self) {
+    (void)self;
+
+    Toy_Value first_argument = Toy_popStack(&vm->stack);
+	Toy_Array* array = TOY_VALUE_AS_ARRAY(first_argument);
+
+	if (array->count == 0) {
+	    return;
+	}
+	Toy_Value *data = array->data;
+
+	dual_pivot_quick_sort(data, 0, array->count, &toy_value_default_compare);
+}
 
 //NOTE: there is no need to call 'Toy_freeValue' on the arguments, as the VM assumes you don't
 Toy_Value Toy_private_handleStringAttributes(Toy_VM* vm, Toy_Value compound, Toy_Value attribute) {
@@ -53,7 +69,6 @@ static void attr_arrayPushBack(Toy_VM* vm, Toy_FunctionNative* self) {
 
 	Toy_Array* array = TOY_VALUE_AS_ARRAY(compound);
 
-	//BUGFIX: check the capacity limit
 	if (array->count == array->capacity) {
 		//correct the source value's pointer
 		array = Toy_resizeArray(array, array->capacity * TOY_ARRAY_EXPANSION_RATE);
@@ -88,13 +103,6 @@ static void attr_arrayPopBack(Toy_VM* vm, Toy_FunctionNative* self) {
 	array->count--;
 
 	Toy_pushStack(&vm->stack, element);
-}
-
-static void attr_arraySort(Toy_VM* vm, Toy_FunctionNative* self) {
-	(void)vm;
-	(void)self;
-
-	//URGENT: attr_arraySort
 }
 
 Toy_Value Toy_private_handleArrayAttributes(Toy_VM* vm, Toy_Value compound, Toy_Value attribute) {

--- a/source/toy_attributes.h
+++ b/source/toy_attributes.h
@@ -12,7 +12,7 @@
 // [x] array.pushBack(x)
 // [x] array.popBack()
 // [x] array.forEach(fn) // fn(x) -> void
-// [ ] array.sort(fn)    // fn(a,b) -> int
+// [x] array.sort(fn)    // fn(a,b) -> int
 // [x] table.length
 // [x] table.insert(x, y)
 // [x] table.hasKey(x)
@@ -23,6 +23,8 @@ Toy_Value Toy_private_handleStringAttributes(Toy_VM* vm, Toy_Value compound, Toy
 Toy_Value Toy_private_handleArrayAttributes(Toy_VM* vm, Toy_Value compound, Toy_Value attribute);
 Toy_Value Toy_private_handleTableAttributes(Toy_VM* vm, Toy_Value compound, Toy_Value attribute);
 Toy_Value Toy_private_handleOpaqueAttributes(Toy_VM* vm, Toy_Value compound, Toy_Value attribute);
+
+static void attr_arrayPushBack(Toy_VM* vm, Toy_FunctionNative* self);
 
 //plug-and-play attributes for custom objects
 typedef Toy_Value (*Toy_OpaqueAttributeHandler)(Toy_VM* vm, Toy_Value compound, Toy_Value attribute);

--- a/source/toy_sort.c
+++ b/source/toy_sort.c
@@ -1,0 +1,83 @@
+#include "toy_value.h"
+
+#include "toy_sort.h"
+
+void insertion_sort(Toy_Value *arr, int low, int high, Toy_Sort_Comparator comp_ptr) {
+    for (int i = low + 1; i <= high; i++) {
+        Toy_Value key = arr[i];
+        int j = i - 1;
+
+        while (j >= low && comp_ptr(&arr[j], &key) == 1) {
+            arr[j + 1] = arr[j];
+            j--;
+        }
+
+        arr[j + 1] = key;
+    }
+}
+
+void dual_pivot_quick_sort(Toy_Value* arr, int low, int high, Toy_Sort_Comparator comp_ptr) {
+    if (high - low < 40) {
+        insertion_sort(arr, low, high, comp_ptr);
+        return;
+    }
+
+    if (low < high) {
+        int lp, rp;
+        rp = partition(arr, low, high, &lp, comp_ptr);
+        dual_pivot_quick_sort(arr, low, lp - 1, comp_ptr);
+        dual_pivot_quick_sort(arr, lp + 1, rp - 1, comp_ptr);
+        dual_pivot_quick_sort(arr, rp + 1, high, comp_ptr);
+    }
+}
+
+int partition(Toy_Value* arr, int low, int high, int* lp, Toy_Sort_Comparator comp_ptr) {
+    int j = low + 1;
+    int g = high - 1;
+    int k = low + 1;
+    Toy_Value *p = &arr[low];
+    Toy_Value *q = &arr[high];
+
+    while (k <= g) {
+        if (comp_ptr(&arr[k], p) == -1) {
+            swap_ptr(&arr[k], &arr[j]);
+            j++;
+            k++;
+            continue;
+        }
+
+        int comp = comp_ptr(&arr[k], q);
+        if (comp == 0 || comp == 1) {
+            while (comp_ptr(&arr[g], q) == 1 && k < g)
+                g--;
+            swap_ptr(&arr[k], &arr[g]);
+            g--;
+            if (comp_ptr(&arr[k], p) == -1) {
+                swap_ptr(&arr[k], &arr[j]);
+                j++;
+            }
+        }
+        k++;
+    }
+
+    j--;
+    g++;
+
+    swap_ptr(&arr[low], &arr[j]);
+    swap_ptr(&arr[high], &arr[g]);
+
+    *lp = j;
+    return g;
+}
+
+int toy_value_default_compare(const Toy_Value *a, const Toy_Value *b) {
+    float fa = a->type == TOY_VALUE_INTEGER ? (float)a->as.integer : a->as.number;
+    float fb = b->type == TOY_VALUE_INTEGER ? (float)b->as.integer : b->as.number;
+    return (fa > fb) - (fa < fb); // returns -1, 0, or 1
+}
+
+static void swap_ptr(Toy_Value* first, Toy_Value* second) {
+    Toy_Value temp = *first;
+    *first = *second;
+    *second = temp;
+}

--- a/source/toy_sort.h
+++ b/source/toy_sort.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "toy_value.h"
+
+typedef int (*Toy_Sort_Comparator)(const Toy_Value*, const Toy_Value*);
+
+void dual_pivot_quick_sort(Toy_Value* arr, int low, int high, Toy_Sort_Comparator comp_ptr);
+
+void insertion_sort(Toy_Value *arr, int low, int high, Toy_Sort_Comparator comp_ptr);
+
+int partition(Toy_Value* arr, int low, int high, int* lp, Toy_Sort_Comparator comp_ptr);
+
+int toy_value_default_compare(const Toy_Value *a, const Toy_Value *b);
+
+static void swap_ptr(Toy_Value* first, Toy_Value* second);


### PR DESCRIPTION
# What I have done
- Added `Toy_Array* Toy_createArray(unsigned int capacity)` for easier array creation
- Added `static void attr_arraySort(Toy_VM* vm, Toy_FunctionNative* self)` which uses the Hybrid Insertion Sort (for small arrays) + Dual Pivot Quick Sort algorithm in C.
- `void dual_pivot_quick_sort(Toy_Value* arr, int low, int high, Toy_Sort_Comparator comp_ptr)` which is a hybrid insertion sort + dual pivot quick sort
- `void insertion_sort(Toy_Value *arr, int low, int high, Toy_Sort_Comparator comp_ptr)` which is just for insertion sort (good if you know the array is <40 elements) but not added to the header.
- `Toy_Sort_Comparator` which is basically `fn(value, value) -> int`, in C it's `typedef int (*Toy_Sort_Comparator)(const Toy_Value*, const Toy_Value*);`

# What I have not done
- attr_arraySort only recognizes `array.sort()` or `sort(array)`, it does not recognize a fn lambda (This can be done easily if lambdas are a thing and you can convert them to function pointers!)
- toy_value_default_compare is a default Toy_Sort_Comparator which only compares floats to numbers
- tested ☠️ 